### PR TITLE
GNU sed vs. BSD sed - compatibility workarounds, etc.

### DIFF
--- a/bump-orbs.sh
+++ b/bump-orbs.sh
@@ -6,15 +6,16 @@ set -euo pipefail
 
 [[ -z "${DEBUG:-}" ]] || set -x
 
+RUNNER_TEMP="${RUNNER_TEMP:-/tmp}"
 GITHUB_OUTPUT="${GITHUB_OUTPUT-output}"
 GITHUB_STEP_SUMMARY="${GITHUB_STEP_SUMMARY-steps.md}"
-ORBS="./orbs"
+ORBS="$(mktemp "${RUNNER_TEMP}/orbs.XXXXXXXX")"
 STANZA='/^orbs:/,/^[^[:space:]][^[:space:]]/' # stanza to match initial orbs section of the config
 
 on_exit() {
   rm -f "${ORBS}"
-  rm -f out-latest
-  rm -f out-updates
+  rm -f "${RUNNER_TEMP}/out-latest"
+  rm -f "${RUNNER_TEMP}/out-updates"
 }
 
 trap on_exit EXIT
@@ -77,28 +78,28 @@ sed -n -E "${STANZA}{/^[[:space:]]*[^:]+[[:space:]]*:[[:space:]]*([^\/]+)\/([^@]
         orb_link="[\`${orb}\`](https://circleci.com/developer/orbs/orb/${orb})"
         if [ "${version}" != "${latest}" ]; then
             sed -i '' -e "${STANZA}s!${orb}@${version}!${orb}@${latest}!g" "${CONFIG}"
-            echo "- bumped ${orb_link} to ${latest} (was ${version})" >> out-updates
+            echo "- bumped ${orb_link} to ${latest} (was ${version})" >> "${RUNNER_TEMP}/out-updates"
         else
-            echo "- ${orb_link} is already at ${latest}" >> out-latest
+            echo "- ${orb_link} is already at ${latest}" >> "${RUNNER_TEMP}/out-latest"
         fi
     fi
 done
 
 
-if [ -s out-updates ]; then
+if [ -s "${RUNNER_TEMP}/out-updates" ]; then
     echo "### Updates" >> "${GITHUB_STEP_SUMMARY}"
-    cat out-updates >> "${GITHUB_STEP_SUMMARY}"
+    cat "${RUNNER_TEMP}/out-updates" >> "${GITHUB_STEP_SUMMARY}"
 fi
 
-if [ -s out-latest ]; then
+if [ -s "${RUNNER_TEMP}/out-latest" ]; then
     echo "### Already up to date" >> "${GITHUB_STEP_SUMMARY}"
-    cat out-latest >> "${GITHUB_STEP_SUMMARY}"
+    cat "${RUNNER_TEMP}/out-latest" >> "${GITHUB_STEP_SUMMARY}"
 fi
 
-if [ -s out-updates ]; then
+if [ -s "${RUNNER_TEMP}/out-updates" ]; then
     EOF="$(dd if=/dev/urandom bs=15 count=1 status=none | base64)"
     { echo "summary<<${EOF}"
-      cat out-updates
+      cat "${RUNNER_TEMP}/out-updates"
       echo "${EOF}"
     } >> "${GITHUB_OUTPUT}"
 else


### PR DESCRIPTION
This PR is based on https://github.com/eddsteel/bump-orb/pull/5; I'll leave this as draft mode unless the preceding one to be accepted, and will do rebasing if it will be merged later.

Here's summary of my changes.

1. Handling of arguments clearer. Properly splitting 3rd argument with whitespaces and turn them into an array
2. Make sure to pass `-i` with suffix value since it's mandatory with BSD sed
3. Specify `-e` to sed to explicitly declare the coming argument as an expression