### PR TITLE
Fix `bump-orbs.sh` and tighten CI checks to detect bogus file contents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,18 +31,14 @@ jobs:
       - name: Check test
         run: |
           if ! grep -E -x '  aws-ecr: circleci/aws-ecr@x\.y\.z' '.github/fixtures/config.yml'; then
-            echo "aws-ecr should be ignored"
-            exit 1
+            { echo "aws-ecr should be ignored"; exit 1; };
           fi
           if ! grep -E -x '  aws-cli: circleci/aws-cli@[0-9]+\.[0-9]+\.[0-9]+' '.github/fixtures/config.yml'; then
-            echo "aws-cli should be bumped"
-            exit 1
+            { echo "aws-cli should be bumped"; exit 1; };
           fi
-          if ! grep -E -x '  node: circleci/node@[0-9]+\.[0-9]+\.[0-9]+' '.github/fixtures/config.yml'; then
-            echo "node should be ignore"
-            exit 1
+          if ! grep -E -x '  node: circleci/node@x\.y\.z' '.github/fixtures/config.yml'; then
+            { echo "node should be ignore"; exit 1; };
           fi
-          if ! grep -E -x '  slack: circleci/slack@x\.y\.z' '.github/fixtures/config.yml'; then
-            echo "slack should be bumped"
-            exit 1
+          if ! grep -E -x '  slack: circleci/slack@[0-9]+\.[0-9]+\.[0-9]+' '.github/fixtures/config.yml'; then
+            { echo "slack should be bumped"; exit 1; };
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
             { echo "aws-cli should be bumped"; exit 1; };
           fi
           if ! grep -E -x '  node: circleci/node@x\.y\.z' '.github/fixtures/config.yml'; then
-            { echo "node should be ignore"; exit 1; };
+            { echo "node should be ignored"; exit 1; };
           fi
           if ! grep -E -x '  slack: circleci/slack@[0-9]+\.[0-9]+\.[0-9]+' '.github/fixtures/config.yml'; then
             { echo "slack should be bumped"; exit 1; };

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,15 +30,19 @@ jobs:
 
       - name: Check test
         run: |
-          if ! grep -q "circleci/aws-ecr@x.y.z" ".github/fixtures/config.yml"; then
-              exit 1
+          if ! grep -E -x '  aws-ecr: circleci/aws-ecr@x\.y\.z' '.github/fixtures/config.yml'; then
+            echo "aws-ecr should be ignored"
+            exit 1
           fi
-          if grep -q "circleci/aws-cli@x.y.z" ".github/fixtures/config.yml"; then
-              exit 1
+          if ! grep -E -x '  aws-cli: circleci/aws-cli@[0-9]+\.[0-9]+\.[0-9]+' '.github/fixtures/config.yml'; then
+            echo "aws-cli should be bumped"
+            exit 1
           fi
-          if ! grep -q "circleci/node@x.y.z" ".github/fixtures/config.yml"; then
-              exit 1
+          if ! grep -E -x '  node: circleci/node@[0-9]+\.[0-9]+\.[0-9]+' '.github/fixtures/config.yml'; then
+            echo "node should be bumped"
+            exit 1
           fi
-          if grep -q "circleci/slack@x.y.z" ".github/fixtures/config.yml"; then
-              exit 1
+          if ! grep -E -x '  slack: circleci/slack@x\.y\.z' '.github/fixtures/config.yml'; then
+            echo "slack should be ignored"
+            exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,10 @@ jobs:
             exit 1
           fi
           if ! grep -E -x '  node: circleci/node@[0-9]+\.[0-9]+\.[0-9]+' '.github/fixtures/config.yml'; then
-            echo "node should be bumped"
+            echo "node should be ignore"
             exit 1
           fi
           if ! grep -E -x '  slack: circleci/slack@x\.y\.z' '.github/fixtures/config.yml'; then
-            echo "slack should be ignored"
+            echo "slack should be bumped"
             exit 1
           fi

--- a/bump-orbs.sh
+++ b/bump-orbs.sh
@@ -78,6 +78,7 @@ sed -n -E "${STANZA}{/^[[:space:]]*[^:]+[[:space:]]*:[[:space:]]*([^\/]+)\/([^@]
         orb_link="[\`${orb}\`](https://circleci.com/developer/orbs/orb/${orb})"
         if [ "${version}" != "${latest}" ]; then
             sed -i.orig -e "${STANZA}s!${orb}@${version}!${orb}@${latest}!g" "${CONFIG}"
+            rm -f "${CONFIG}.orig"
             echo "- bumped ${orb_link} to ${latest} (was ${version})" >> "${OUT_UPDATES}"
         else
             echo "- ${orb_link} is already at ${latest}" >> "${OUT_LATEST}"

--- a/bump-orbs.sh
+++ b/bump-orbs.sh
@@ -72,7 +72,7 @@ sed -n -E "${STANZA}{/^[[:space:]]*[^:]+[[:space:]]*:[[:space:]]*([^\/]+)\/([^@]
     | while read -r line; do
     orb="$(echo "${line}" | cut -f 1 -d'@')"
     version="$(echo "${line}" | cut -f 2 -d'@')"
-    latest="$(grep "${orb}" "${ORBS}" || true | cut -f 2 -d'@')"
+    latest="$({ grep "${orb}" "${ORBS}" || true; } | cut -f 2 -d'@')"
 
     if [ -n "${latest:-}" ]; then
         orb_link="[\`${orb}\`](https://circleci.com/developer/orbs/orb/${orb})"


### PR DESCRIPTION
Follow-up to #6 to address following issues

1. Temporary file .orig` (e.g. `.github/fixtures/config.yml.orig`) will be left  after script execution
2. Generate bogus Orb references like like `circleci/aws-cli/circleci/aws-cli@5.3.4` due to inappropriate handling of stdout from grep
3. CI could not detect the problematic file generation

To deal with the issues, I've tighten up the CI configurations to detect the problem. I've also make fixes to solve the intrinsic problems in the script.

*1
```
orbs:
  aws-ecr: circleci/aws-ecr@x.y.z
  aws-cli: circleci/aws-cli@circleci/aws-cli@5.3.4
  node: circleci/node@x.y.z
  slack: circleci/slack@circleci/slack@5.1.1
````